### PR TITLE
correccion al incluir bibliografia a tabla de contenidos

### DIFF
--- a/umemoria.cls
+++ b/umemoria.cls
@@ -61,12 +61,14 @@
 %% Agregar la bibliografía al índice
 \let\oldbib\bibliography
 \renewcommand{\bibliography}[1]{%
-	\oldbib{#1}%
+	\cleardoublepage
+	\phantomsection
 	\if@en
 		\addcontentsline{toc}{chapter}{\protect\numberline{}Bibliography}%
 	\else
 		\addcontentsline{toc}{chapter}{\protect\numberline{}Bibliograf\'ia}%
 	\fi
+	\oldbib{#1}%
 }
 \addto\captionsspanish{\renewcommand\listtablename{Índice de Tablas}}
 \addto\captionsspanish{\renewcommand\listfigurename{Índice de Ilustraciones}}


### PR DESCRIPTION
Al insertar la bibliografia en la tabla de contenidos como se encuentra actualmente, se genera con el numero de la última página de la bibliografia. Por ejemplo, si esta comienza en la pagina 31 y termina en la 32, en la tabla de contenidos dirá: Bibliografía....32.

Agregando un par de comandos y cambiando el orden de las instrucciones se solucionó al menos para mi.