### PR TITLE
cambios sobre apendices/anexos

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -32,6 +32,12 @@
 
 \usepackage{lipsum}
 
+%%% apendices -> anexos
+\addto\captionsspanish{%
+  \renewcommand\appendixname{Anexo}
+  \renewcommand\appendixpagename{Anexos}
+}
+
 \begin{document}
 
 \frontmatter
@@ -75,7 +81,21 @@ Una dedicatoria corta.
 \bibliography{bibliografia}
 
 % opcional ...
+
+% crea linea Anexos en tabla de contenidos
+\cleardoublepage
+\phantomsection
+\addcontentsline{toc}{chapter}{\protect{}Anexos}
+
 \begin{appendices}
-\input{anexoA.tex}
+    % Agrega el titulo ANEXOS
+    \let\oldclearpage\clearpage
+    \cleardoublepage
+    \let\clearpage\relax
+    \vspace*{50pt} % espacio al inicio de un capitulo
+    \noindent{ \huge\bfseries ANEXOS\par}
+    \input{anexoA.tex} % primer anexo
+    \let\clearpage\oldclearpage
+    % inserte aqui el resto de anexos
 \end{appendices}
 \end{document}


### PR DESCRIPTION
Cambios generados a partir de rechazo de memoria por parte de biblioteca.
Estos cambios incluyen: 
- Cambiar la palabra Apendice(s) a Anexo(s)
- Agregar linea Anexos a tabla de contenidos
- Crear titulo ANEXOS al comienzo del capitulo de anexos

El ultimo cambio se hizo un poco forzado por decirlo de alguna forma, no logré encontrar algo del paquete de apendices que permitiera hacer algo parecido. Tambien genera espacios de tamaños quizas no deseados, pero fueron aceptados por biblioteca.